### PR TITLE
fix: Split concurrency for builds for each branch

### DIFF
--- a/.github/workflows/build-ui.yml
+++ b/.github/workflows/build-ui.yml
@@ -19,7 +19,7 @@ permissions:
 # Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
 # However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
 concurrency:
-  group: "pages"
+  group: "pages-${{ github.head_ref || github.ref_name }}"
   cancel-in-progress: false
 
 jobs:


### PR DESCRIPTION
<h3>PR Summary by Qodo</h3>

Fix GitHub Pages workflow concurrency to be per-branch
<code>🐞 Bug fix</code> <code>⚙️ Configuration changes</code> <code>🕐 Less than 5 minutes</code>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">

<h3>Walkthroughs</h3>

<details open>
<summary>Description</summary>

<br/>

<pre>
• Scope GitHub Actions concurrency group to the branch to avoid cross-branch blocking.
• Keep in-progress deployments running while allowing parallel runs on different branches.
</pre>
</details>

<details>
<summary>Diagram</summary>

<br/>

```mermaid
graph TD
  A["build-ui workflow"] --> B{"Concurrency group"} --> C["GitHub Pages deploy"]
  B --> D["Branch/ref name"]
```

</details>




<details>
<summary>High-Level Assessment</summary>

<br/>

The following are alternative approaches to this PR:

<details>
<summary><b>1. Use github.workflow + github.ref for grouping</b></summary>

- ➕ Avoids potential group-name collisions if multiple workflows deploy Pages
- ➕ More explicit uniqueness across workflow files
- ➖ Slightly more verbose
- ➖ Not necessary if only this workflow uses the Pages concurrency group

</details>

<details>
<summary><b>2. Group by environment (e.g., pages-prod vs pages-preview)</b></summary>

- ➕ Aligns concurrency with deployment targets rather than branches
- ➕ Can better reflect promotion flows
- ➖ Does not solve cross-branch blocking if all branches target same environment
- ➖ Requires clearer environment modeling in the workflow

</details>

**Recommendation:** Current approach is appropriate: scoping the group to `${{ github.head_ref || github.ref_name }}` directly addresses the cross-branch concurrency issue with minimal change. Consider adding `${{ github.workflow }}` to the group if there is (or will be) more than one workflow deploying to Pages.

</details>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">

<h3>File Changes</h3>

<details>
<summary><strong>Other</strong> (1)</summary>

<blockquote>
<details>
<summary><strong>build-ui.yml</strong> <code>Make Pages concurrency group branch-scoped</code> <code>+1/-1</code></summary>

<br/>

>Make Pages concurrency group branch-scoped
>
><pre>
>• Updates the workflow concurrency group from a single shared value (&quot;pages&quot;) to a branch/ref-specific value (&quot;pages-${{ github.head_ref || github.ref_name }}&quot;). This prevents runs from different branches from blocking each other while keeping &#x27;cancel-in-progress: false&#x27; behavior.
></pre>
>
><a href='https://github.com/ether/ether-scan-ui/pull/297/files#diff-67f6f98ad3468e517674ec0c18ded8ef66d85c2e153faf086f004ee9214be0b1'>.github/workflows/build-ui.yml</a>
<hr/>

</details>
</blockquote>

</details>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">


<a href="https://www.qodo.ai"><img src="https://www.qodo.ai/wp-content/uploads/2025/03/qodo-logo.svg" width="80" alt="Qodo Logo"></a>